### PR TITLE
Make 'to' key optional in metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __pycache__
 node_modules/
 attrs_serde.egg-info/
 .idea/
+venv/

--- a/attrs_serde/attrs_serde.py
+++ b/attrs_serde/attrs_serde.py
@@ -10,7 +10,7 @@ def serde(cls=None, from_key="from", to_key="to"):
 
         to_fields = pipe(
             fields(cls),
-            map(lambda a: (a, get_in([to_key], a.metadata))),
+            map(lambda a: (a, get_in([to_key], a.metadata, [a.name]))),
             filter(lambda f: f[1]),
             list,
         )


### PR DESCRIPTION
The problem: You need to write a lot of boilerplate
```
@serde
@attr.s
class AccountData:
    account: int = attr.ib(metadata={"to": ["Account"]})
    phone: str = attr.ib(metadata={"to": ["phone"]})
```
Right now serde will not serialize fields, which doesn't have `metadata` with `to` key in it: `attr.ib(metadata={"to": ["name"]})` 
So you need to specify it even if field have the same name.

For example, currently this example will be serialized as `{"Account": ...}`
With this PR it will be serialized as `{"Account": ..., "phone": ...}`, which is more predictable
```
@serde
@attr.s
class AccountData:
    account: int = attr.ib(metadata={"to": ["Account"]})
    phone: str = attr.ib()
```

And in case if you don't want to serialize some of the fields you can use inheritance:
```
@serde
@attr.s
class AccountDataSerialized:
    account: int = attr.ib(metadata={"to": ["Account"]})
    phone: str = attr.ib()
    
@attr.s
class AccountData(AccountDataSerialized):
    internal_not_serialized_field = attr.ib()
```

So when you call `AccountData.to_dict()` it will be serialized as  `{"Account": ..., "phone": ...}`

